### PR TITLE
Fixes the milestone labels and adds a discord ping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -605,7 +605,8 @@
     "@tsconfig/node12": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.3.tgz",
-      "integrity": "sha512-DZ3vMr6PEGEGxMKjgaMQ/A4gxbqRC00tn0KPnkg+mi761w/eAv4laTqBQdYdJvvMEMt5BBQ4DR16jBEBRN0Icw=="
+      "integrity": "sha512-DZ3vMr6PEGEGxMKjgaMQ/A4gxbqRC00tn0KPnkg+mi761w/eAv4laTqBQdYdJvvMEMt5BBQ4DR16jBEBRN0Icw==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.9",
@@ -691,6 +692,29 @@
       "version": "14.0.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
       "integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw=="
+    },
+    "@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
     "@octokit/webhooks": "^6.3.2",
     "@types/minimatch": "^3.0.3",
     "minimatch": "^3.0.4",
-    "parse-diff": "^0.6.0"
+    "parse-diff": "^0.6.0",
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@tsconfig/node12": "^1.0.3",
     "@types/jest": "^24.0.23",
+    "@types/node-fetch": "^2.5.7",
     "codeowners": "^4.1.1",
     "jest": "^24.9.0",
     "prettier": "^2.0.5",

--- a/src/anyRepoHandleIssue.ts
+++ b/src/anyRepoHandleIssue.ts
@@ -20,6 +20,10 @@ export const handleIssuePayload = async (payload: WebhookPayloadIssues, context:
 
   if (payload.repository.name === "TypeScript") {
     run("Adding repro tags from issue bodies", addOrRemoveReprosLabelOnIssue)
+
+    if (payload.action === "labeled") {
+
+    } 
   }
 
   context.res = {

--- a/src/anyRepoHandleIssue.ts
+++ b/src/anyRepoHandleIssue.ts
@@ -4,6 +4,7 @@ import { Octokit } from "@octokit/rest"
 import { sha } from "./sha"
 import { addOrRemoveReprosLabelOnIssue } from "./checks/addOrRemoveReprosLabel"
 import { createGitHubClient } from "./util/createGitHubClient"
+import { pingDiscordForReproRequests } from "./checks/pingDiscordForReproRequests"
 
 export const handleIssuePayload = async (payload: WebhookPayloadIssues, context: Context) => {
   const api = createGitHubClient()
@@ -22,7 +23,7 @@ export const handleIssuePayload = async (payload: WebhookPayloadIssues, context:
     run("Adding repro tags from issue bodies", addOrRemoveReprosLabelOnIssue)
 
     if (payload.action === "labeled") {
-
+      run("Seeing if we should ping discord for the label", pingDiscordForReproRequests)
     } 
   }
 

--- a/src/checks/addMilestoneLabelsToPRs.test.ts
+++ b/src/checks/addMilestoneLabelsToPRs.test.ts
@@ -8,80 +8,82 @@ import { getRelatedIssues } from "../pr_meta/getRelatedIssues"
 const mockGetRelatedIssues = (getRelatedIssues as any) as jest.Mock
 
 describe(addMilestoneLabelsToPRs, () => {
-
   it("Keeps existing labels from the PR", async () => {
     const { mockAPI, api } = createMockGitHubClient()
     mockGetRelatedIssues.mockResolvedValue([{ assignees: [] }])
 
     const pr = getPRFixture("opened")
-    pr.pull_request.labels = [{name: "Something"}, {name: "Other"}]
+    pr.pull_request.labels = [{ name: "Something" }, { name: "Other" }]
 
     await addMilestoneLabelsToPRs(api, pr, getFakeLogger())
 
-    expect(mockAPI.issues.replaceLabels).toHaveBeenCalledWith({
+    expect(mockAPI.issues.addLabels).toHaveBeenCalledWith({
       issue_number: 35454,
       owner: "microsoft",
       repo: "TypeScript",
-      labels: ["Something", "Other", "For Uncommitted Bug"]
+      labels: ["For Uncommitted Bug"],
     })
+    expect(mockAPI.issues.removeLabel).not.toHaveBeenCalled()
   })
 
   it("Makes the PR Uncommitted", async () => {
     const { mockAPI, api } = createMockGitHubClient()
-    mockGetRelatedIssues.mockResolvedValue([
-      { assignees: [] }
-    ])
+    mockGetRelatedIssues.mockResolvedValue([{ assignees: [] }])
 
     const pr = getPRFixture("opened")
     pr.pull_request.body = `fixes #1123`
 
     await addMilestoneLabelsToPRs(api, pr, getFakeLogger())
 
-    expect(mockAPI.issues.replaceLabels).toHaveBeenCalledWith({
+    expect(mockAPI.issues.addLabels).toHaveBeenCalledWith({
       issue_number: 35454,
       owner: "microsoft",
       repo: "TypeScript",
-      labels: ["For Uncommitted Bug"]
+      labels: ["For Uncommitted Bug"],
     })
   })
 
   it("Removes a label if milestone doesn't match the current labels", async () => {
     const { mockAPI, api } = createMockGitHubClient()
-    mockGetRelatedIssues.mockResolvedValue([
-      { assignees: [], milestone: { title: "Not Backlog" } }
-    ])
+    mockGetRelatedIssues.mockResolvedValue([{ assignees: [], milestone: { title: "Not Backlog" } }])
 
     const pr = getPRFixture("opened")
     pr.pull_request.body = `fixes #1123`
-    pr.pull_request.labels = [{name: "For Backlog Bug"}]
+    pr.pull_request.labels = [{ name: "For Backlog Bug" }]
 
     await addMilestoneLabelsToPRs(api, pr, getFakeLogger())
 
-    expect(mockAPI.issues.replaceLabels).toHaveBeenCalledWith({
+    expect(mockAPI.issues.removeLabel).toHaveBeenCalledWith({
+      issue_number: 35454,
+      name: "For Backlog Bug",
+      owner: "microsoft",
+      repo: "TypeScript",
+    })
+
+
+    expect(mockAPI.issues.addLabels).toHaveBeenCalledWith({
       issue_number: 35454,
       owner: "microsoft",
       repo: "TypeScript",
-      labels: ["For Milestone Bug"]
+      labels: ["For Milestone Bug"],
     })
   })
 
   it("Removes a label if milestone doesn't match the current labels", async () => {
     const { mockAPI, api } = createMockGitHubClient()
-    mockGetRelatedIssues.mockResolvedValue([
-      { assignees: [], milestone: { title: "Not Backlog" } }
-    ])
+    mockGetRelatedIssues.mockResolvedValue([{ assignees: [], milestone: { title: "Not Backlog" } }])
 
     const pr = getPRFixture("opened")
     pr.pull_request.body = `fixes #1123`
-    pr.pull_request.labels = [{name: "For Backlog Bug"}]
+    pr.pull_request.labels = [{ name: "For Backlog Bug" }]
 
     await addMilestoneLabelsToPRs(api, pr, getFakeLogger())
 
-    expect(mockAPI.issues.replaceLabels).toHaveBeenCalledWith({
+    expect(mockAPI.issues.addLabels).toHaveBeenCalledWith({
       issue_number: 35454,
       owner: "microsoft",
       repo: "TypeScript",
-      labels: ["For Milestone Bug"]
+      labels: ["For Milestone Bug"],
     })
   })
 })

--- a/src/checks/addMilestoneLabelsToPRs.ts
+++ b/src/checks/addMilestoneLabelsToPRs.ts
@@ -46,11 +46,13 @@ export const addMilestoneLabelsToPRs = async (api: Octokit, payload: WebhookPayl
   }
 
   const labelsNeedingToAdd = Object.keys(houseKeepingLabels).filter(l => houseKeepingLabels[l as HouseKeepingKeys])
-  const labelsNeedingToRemove = Object.keys(houseKeepingLabels).filter(l => !houseKeepingLabels[l as HouseKeepingKeys])
+  const labelsNeedingToRemove = Object.keys(houseKeepingLabels).filter(l => !houseKeepingLabels[l as HouseKeepingKeys]).filter(f => pull_request.labels.find(l => l.name === f))
 
-  const newLabels = [...pull_request.labels.map(l => l.name), ...labelsNeedingToAdd].filter(l => !labelsNeedingToRemove.includes(l))
+  for (const toRemove of labelsNeedingToRemove) {
+    await api.issues.removeLabel({ ...thisIssue, name: toRemove })
+  }
 
-  if (labelsNeedingToRemove.length || labelsNeedingToRemove.length) {
-    api.issues.replaceLabels({...thisIssue, labels: newLabels })
+  if (labelsNeedingToAdd.length) {
+    await api.issues.addLabels({ ...thisIssue, labels: labelsNeedingToAdd })
   }
 }

--- a/src/checks/pingDiscordForReproRequests.test.ts
+++ b/src/checks/pingDiscordForReproRequests.test.ts
@@ -1,0 +1,54 @@
+jest.mock("node-fetch")
+import { createMockGitHubClient, getIssueFixture, getPRFixture } from "../util/tests/createMockGitHubClient"
+import { getFakeLogger } from "../util/tests/createMockContext"
+
+import { mergeThroughCodeOwners, mergePhrase } from "./mergeThroughCodeOwners"
+import { getContents } from "../util/getContents"
+import { pingDiscordForReproRequests } from "./pingDiscordForReproRequests"
+import fetch from "node-fetch"
+
+const genericWebhook = {
+  comment: {
+    body: mergePhrase,
+    user: {
+      login: "orta",
+    },
+  },
+  issue: {
+    number: 1234,
+  },
+  repository: {
+    owner: {
+      login: "microsoft",
+    },
+    name: "TypeScript-Website",
+  },
+}
+
+describe("pinging discord for new repro requests", () => {
+  it("NOOPs on labels which aren't right", async () => {
+    const { api } = createMockGitHubClient()
+    const payload = getIssueFixture("labeled")
+
+    await pingDiscordForReproRequests(api, payload, getFakeLogger())
+
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it("Keeps existing labels from the PR", async () => {
+    const { mockAPI, api } = createMockGitHubClient()
+
+    const payload = getIssueFixture("labeled")
+    // @ts-ignore
+    payload.label = { name: "Repro Requested" }
+
+    process.env.REPRO_REQUEST_DISCORD_WEBHOOK = "12345"
+    await pingDiscordForReproRequests(api, payload, getFakeLogger())
+
+    expect(fetch).toHaveBeenCalledWith("12345", {
+      body:
+        '{"content":"Repro requested on #35430","embeds":[{"title":"Suggestions for variable like name from type name","description":"\\r\\n```ts\\r\\nconst us/*here*/ : UserService\\r\\n// us -> userService\\r\\n```\\r\\n\\r\\n\\r\\n## Examples\\r\\n\\r\\n\\r\\n\\r\\n","url":"https://github.com/microsoft/TypeScript/issues/35430"}]}',
+      method: "POST",
+    })
+  })
+})

--- a/src/checks/pingDiscordForReproRequests.ts
+++ b/src/checks/pingDiscordForReproRequests.ts
@@ -1,0 +1,38 @@
+import { WebhookPayloadIssues } from "@octokit/webhooks"
+import { Octokit } from "@octokit/rest"
+import { Logger } from "@azure/functions"
+import fetch from "node-fetch"
+
+/**
+ * Ping the discord channel when the label "Repro Requested" is added to an issue
+ */
+export const pingDiscordForReproRequests = async (api: Octokit, payload: WebhookPayloadIssues, logger: Logger) => {
+  const { issue } = payload
+
+  const label = (payload as any).label 
+  if (label && label.name && label.name === "Repro Requested") {
+    
+    if (!process.env.REPRO_REQUEST_DISCORD_WEBHOOK) throw new Error("No process var for REPRO_REQUEST_DISCORD_WEBHOOK")
+
+    // https://discord.com/developers/docs/resources/webhook#execute-webhook
+    
+    let body = issue.body.slice(0, 199)
+    // The template has comments which might have been kept in
+    if (issue.body.includes("𝗦𝗧𝗢𝗣") && issue.body.includes("## Use Cases")) {
+      // https://regex101.com/r/uEmvAZ/1
+      const stripComments = /<!--[^>]*-->/g
+      body = issue.body.replace(stripComments, "").split("## Use Cases")[1].split("## Checklist")[0].slice(0, 199)
+    } 
+
+    const webhook = {
+      content: `Repro requested on #${issue.number}`,
+      embeds: [{
+        title: issue.title,
+        description: body.length === 200 ? body + "..." : body,
+        url: issue.html_url
+      }]
+    }
+
+    fetch(process.env.REPRO_REQUEST_DISCORD_WEBHOOK, { method: "POST", body: JSON.stringify(webhook) })
+  }
+}

--- a/src/util/tests/createMockGitHubClient.ts
+++ b/src/util/tests/createMockGitHubClient.ts
@@ -30,6 +30,7 @@ export const createMockGitHubClient = () => {
       addAssignees: jest.fn(),
       replaceLabels: jest.fn(),
       addLabels: jest.fn(),
+      removeLabel: jest.fn(),
       get: jest.fn(),
     },
     pulls: {
@@ -84,6 +85,7 @@ export const createFakeGitHubClient = () => {
       addAssignees: Promise.resolve({}),
       replaceLabels: Promise.resolve({}),
       addLabels: Promise.resolve({}),
+      removeLabel: Promise.resolve({}),
       get: Promise.resolve({}),
     },
     pulls: {


### PR DESCRIPTION
I think 'replaceLabels' was being a bit problematic, so now we manually add or remove the milestone labels

Also adds a ping to discord when we add a particular label to an issue