### PR TITLE
Polish addCommentToUncommittedPRs

### DIFF
--- a/src/checks/addCommentToUncommittedPRs.test.ts
+++ b/src/checks/addCommentToUncommittedPRs.test.ts
@@ -23,7 +23,7 @@ describe(addCommentToUncommittedPRs, () => {
       issue_number: 35454,
       owner: "microsoft",
       repo: "TypeScript",
-      body: "The PR doesn't have any linked issues. Please open an issue that references this PR. From there we can discuss and prioritise.",
+      body: "This PR doesn't have any linked issues. Please open an issue that references this PR. From there we can discuss and prioritise.",
     })
     expect(mockAPI.issues.removeLabel).not.toHaveBeenCalled()
   })
@@ -43,7 +43,7 @@ describe(addCommentToUncommittedPRs, () => {
       issue_number: 35454,
       owner: "microsoft",
       repo: "TypeScript",
-      body: "The TypeScript team hasn't accepted the linked issue #1. This makes it less likely that we'll review or accept this PR. Try to get the originating issue accepted."
+      body: "The TypeScript team hasn't accepted the linked issue #1. If you can get it accepted, this PR will have a better chance of being reviewed."
     })
   })
   it("Does not add a comment to an uncommented PR linked to an uncommitted suggestion from the TS team", async () => {

--- a/src/checks/addCommentToUncommittedPRs.ts
+++ b/src/checks/addCommentToUncommittedPRs.ts
@@ -9,7 +9,7 @@ import { isMemberOfTSTeam } from "../pr_meta/isMemberOfTSTeam"
  */
 export const addCommentToUncommittedPRs = async (api: Octokit, payload: WebhookPayloadPullRequest, logger: Logger) => {
   const { repository: repo, pull_request } = payload
-  if (pull_request.merged) {
+  if (pull_request.merged || !(await isMemberOfTSTeam(pull_request.user.login, api, logger))) {
     return
   }
 
@@ -32,7 +32,7 @@ export const addCommentToUncommittedPRs = async (api: Octokit, payload: WebhookP
   else {
     const isSuggestion = relatedIssues.some(issue => issue.labels?.find(l => l.name === "Suggestion"))
     const isCommitted = relatedIssues.some(issue => issue.labels?.find(l => l.name === "Committed" || l.name === "Experience Enhancement" || l.name === "help wanted"))
-    if (isSuggestion && !isCommitted && !(await isMemberOfTSTeam(pull_request.user.login, api, logger))) {
+    if (isSuggestion && !isCommitted) {
       const comments = (await api.issues.listComments(thisIssue)).data
       if (!comments || !comments.find(c => c.body.startsWith('The TypeScript team has'))) {
         await api.issues.createComment({

--- a/src/checks/addCommentToUncommittedPRs.ts
+++ b/src/checks/addCommentToUncommittedPRs.ts
@@ -9,7 +9,7 @@ import { isMemberOfTSTeam } from "../pr_meta/isMemberOfTSTeam"
  */
 export const addCommentToUncommittedPRs = async (api: Octokit, payload: WebhookPayloadPullRequest, logger: Logger) => {
   const { repository: repo, pull_request } = payload
-  if (pull_request.merged || !(await isMemberOfTSTeam(pull_request.user.login, api, logger))) {
+  if (pull_request.merged || await isMemberOfTSTeam(pull_request.user.login, api, logger)) {
     return
   }
 

--- a/src/checks/addCommentToUncommittedPRs.ts
+++ b/src/checks/addCommentToUncommittedPRs.ts
@@ -9,24 +9,23 @@ import { isMemberOfTSTeam } from "../pr_meta/isMemberOfTSTeam"
  */
 export const addCommentToUncommittedPRs = async (api: Octokit, payload: WebhookPayloadPullRequest, logger: Logger) => {
   const { repository: repo, pull_request } = payload
-  pull_request.number
+  if (pull_request.merged) {
+    return
+  }
 
   const relatedIssues = await getRelatedIssues(pull_request.body, repo.owner.login, repo.name, api)
+
   const thisIssue = {
     repo: repo.name,
     owner: repo.owner.login,
     issue_number: pull_request.number,
   }
-    // if no related issues, comment "please open an issue first. we'll prioritise and discuss there"
-    // if related issue(s) have no tag like Exp Enhancement, Accepted, Help Wanted, Milestone: X, Backlog, comment "watch out, we may not take this. make sure the issue is accepted first"
-    // note: all these are technically exempt for core team members, although they should know better, so
-
   if (!relatedIssues || relatedIssues.length === 0) {
     const comments = (await api.issues.listComments(thisIssue)).data
     if (!comments || !comments.find(c => c.body.startsWith('The PR doesn'))) {
       await api.issues.createComment({
         ...thisIssue,
-        body: "The PR doesn't have any linked issues. Please open an issue that references this PR. From there we can discuss and prioritise."
+        body: "This PR doesn't have any linked issues. Please open an issue that references this PR. From there we can discuss and prioritise."
       })
     }
   }
@@ -38,7 +37,7 @@ export const addCommentToUncommittedPRs = async (api: Octokit, payload: WebhookP
       if (!comments || !comments.find(c => c.body.startsWith('The TypeScript team has'))) {
         await api.issues.createComment({
           ...thisIssue,
-          body: `The TypeScript team hasn't accepted the linked issue #${relatedIssues[0].number}. This makes it less likely that we'll review or accept this PR. Try to get the originating issue accepted.`
+          body: `The TypeScript team hasn't accepted the linked issue #${relatedIssues[0].number}. If you can get it accepted, this PR will have a better chance of being reviewed.`
         })
       }
     }


### PR DESCRIPTION
1. Clean up dead code/comments.
2. Don't comment on merged PRs.
3. Improve wording a little.
4. Move isTeamMember check earlier, so that it applies to both kinds of comments.