### PR TITLE
Support infinitely paginating for PR comments

### DIFF
--- a/src/anyRepoHandlePullRequest.ts
+++ b/src/anyRepoHandlePullRequest.ts
@@ -58,7 +58,7 @@ const generatePRInfo = async (api: Octokit, payload: WebhookPayloadPullRequest, 
   const options = api.issues.listComments.endpoint.merge(thisIssue)
   const comments: Octokit.IssuesListCommentsResponse = await api.paginate(options)
 
-  const authorIsMemberOfTSTeam = await isMemberOfTSTeam(payload.sender.login, api, logger)
+  const authorIsMemberOfTSTeam = await isMemberOfTSTeam(payload.pull_request.user.login, api, logger)
   const relatedIssues = await getRelatedIssues(pull_request.body, repo.owner.login, repo.name, api)
 
   return {

--- a/src/anyRepoHandlePullRequest.ts
+++ b/src/anyRepoHandlePullRequest.ts
@@ -8,6 +8,8 @@ import { addMilestoneLabelsToPRs } from "./checks/addMilestoneLabelsToPRs"
 import { addCommentToUncommittedPRs } from "./checks/addCommentToUncommittedPRs"
 import { Octokit } from "@octokit/rest"
 import { sha } from "./sha"
+import { isMemberOfTSTeam } from "./pr_meta/isMemberOfTSTeam"
+import { getRelatedIssues } from "./pr_meta/getRelatedIssues"
 
 export const handlePullRequestPayload = async (payload: WebhookPayloadPullRequest, context: Context) => {
   const api = createGitHubClient()
@@ -15,24 +17,54 @@ export const handlePullRequestPayload = async (payload: WebhookPayloadPullReques
 
   const run = (
     name: string,
-    fn: (api: Octokit, payload: WebhookPayloadPullRequest, logger: Logger) => Promise<void>
+    fn: (api: Octokit, payload: WebhookPayloadPullRequest, logger: Logger, pr: PRInfo) => Promise<void>,
+    pr: PRInfo
   ) => {
     context.log.info(`\n\n## ${name}\n`)
     ran.push(name)
-    return fn(api, payload, context.log)
+    return fn(api, payload, context.log, pr)
   }
 
   if (payload.repository.name === "TypeScript") {
-    await run("Assigning Self to Core Team PRs", assignSelfToNewPullRequest)
-    await run("Add a core team label to PRs", addLabelForTeamMember)
-    await run("Assign core team to PRs which affect their issues", assignTeamMemberForRelatedPR)
-    await run("Adding milestone related labels", addMilestoneLabelsToPRs)
-    await run("Adding comment on uncommitted PRs", addCommentToUncommittedPRs)
+    const pr = await generatePRInfo(api, payload, context.log)
+
+    await run("Assigning Self to Core Team PRs", assignSelfToNewPullRequest, pr)
+    await run("Add a core team label to PRs", addLabelForTeamMember, pr)
+    await run("Assign core team to PRs which affect their issues", assignTeamMemberForRelatedPR, pr)
+    await run("Adding milestone related labels", addMilestoneLabelsToPRs, pr)
+    await run("Adding comment on uncommitted PRs", addCommentToUncommittedPRs, pr)
   }
 
   context.res = {
     status: 200,
     headers: { sha: sha },
     body: ran.length ? `PR success, ran: ${ran.join(", ")}`: "Success, NOOP",
+  }
+}
+
+export type UnPromise<T> = T extends Promise<infer U> ? U : T
+// The return type of generatePRInfo
+export type PRInfo = UnPromise<ReturnType<typeof generatePRInfo>>
+
+const generatePRInfo = async (api: Octokit, payload: WebhookPayloadPullRequest, logger: Logger) => {
+  const { repository: repo, pull_request } = payload
+
+  const thisIssue = {
+    repo: repo.name,
+    owner: repo.owner.login,
+    issue_number: pull_request.number,
+  }
+  
+  const options = api.issues.listComments.endpoint.merge(thisIssue)
+  const comments: Octokit.IssuesListCommentsResponse = await api.paginate(options)
+
+  const authorIsMemberOfTSTeam = await isMemberOfTSTeam(payload.sender.login, api, logger)
+  const relatedIssues = await getRelatedIssues(pull_request.body, repo.owner.login, repo.name, api)
+
+  return {
+    thisIssue,
+    authorIsMemberOfTSTeam,
+    relatedIssues,
+    comments 
   }
 }

--- a/src/checks/addCommentToUncommittedPRs.test.ts
+++ b/src/checks/addCommentToUncommittedPRs.test.ts
@@ -7,8 +7,10 @@ import { getFakeLogger } from "../util/tests/createMockContext"
 
 import { getRelatedIssues } from "../pr_meta/getRelatedIssues"
 import { isMemberOfTSTeam } from "../pr_meta/isMemberOfTSTeam"
+import { PRInfo } from "../anyRepoHandlePullRequest"
 const mockGetRelatedIssues = (getRelatedIssues as any) as jest.Mock
 const mockIsMember = (isMemberOfTSTeam as any) as jest.Mock
+
 
 describe(addCommentToUncommittedPRs, () => {
   it("Adds a comment to an uncommented, unlinked PR", async () => {
@@ -17,7 +19,8 @@ describe(addCommentToUncommittedPRs, () => {
     const pr = getPRFixture("opened")
     pr.pull_request.body = "Cool Ghosts"
 
-    await addCommentToUncommittedPRs(api, pr, getFakeLogger())
+    const info = createInfo()
+    await addCommentToUncommittedPRs(api, pr, getFakeLogger(),info)
 
     expect(mockAPI.issues.createComment).toHaveBeenCalledWith({
       issue_number: 35454,
@@ -30,14 +33,12 @@ describe(addCommentToUncommittedPRs, () => {
 
   it("Adds a comment to an uncommented PR linked to uncommitted suggestion", async () => {
     const { mockAPI, api } = createMockGitHubClient()
-    mockAPI.issues.listComments.mockResolvedValue({ data: [] })
-    mockGetRelatedIssues.mockResolvedValue([{ number: 1, labels: [{ name: "Suggestion" }] }])
-    mockIsMember.mockResolvedValue(false)
 
     const pr = getPRFixture("opened")
     pr.pull_request.body = `fixes #1`
 
-    await addCommentToUncommittedPRs(api, pr, getFakeLogger())
+    const info = createInfo({ relatedIssues: [{ number: 1, labels: [({ name: "Suggestion" })] }]} as any)
+    await addCommentToUncommittedPRs(api, pr, getFakeLogger(), info)
 
     expect(mockAPI.issues.createComment).toHaveBeenCalledWith({
       issue_number: 35454,
@@ -46,30 +47,28 @@ describe(addCommentToUncommittedPRs, () => {
       body: "The TypeScript team hasn't accepted the linked issue #1. If you can get it accepted, this PR will have a better chance of being reviewed."
     })
   })
+
   it("Does not add a comment to an uncommented PR linked to an uncommitted suggestion from the TS team", async () => {
     const { mockAPI, api } = createMockGitHubClient()
-    mockAPI.issues.listComments.mockResolvedValue({ data: [] })
-    mockGetRelatedIssues.mockResolvedValue([{ number: 1, labels: [{ name: "Suggestion" }] }])
-    mockIsMember.mockResolvedValue(true)
 
     const pr = getPRFixture("opened")
     pr.pull_request.body = `fixes #1`
 
-    await addCommentToUncommittedPRs(api, pr, getFakeLogger())
+    const info = createInfo({  authorIsMemberOfTSTeam: true,  relatedIssues: [{ number: 1, labels: [{ name: "Suggestion" }] }] as any} )
+    await addCommentToUncommittedPRs(api, pr, getFakeLogger(), info)
 
     expect(mockAPI.issues.createComment).not.toHaveBeenCalled()
   })
+
   for (const allowed of ["Experience Enhancement", "Committed", "help wanted"]) {
     it("Does not add a comment to an uncommented PR linked to a suggestion with the label " + allowed, async () => {
       const { mockAPI, api } = createMockGitHubClient()
-      mockAPI.issues.listComments.mockResolvedValue({ data: [] })
-      mockGetRelatedIssues.mockResolvedValue([{ number: 1, labels: [{ name: "Suggestion" }, { name: allowed }] }])
-      mockIsMember.mockResolvedValue(false)
-
+      
       const pr = getPRFixture("opened")
       pr.pull_request.body = `fixes #1`
-
-      await addCommentToUncommittedPRs(api, pr, getFakeLogger())
+      
+      const info = createInfo({ relatedIssues: [{ number: 1, labels: [{ name: "Suggestion" }, { name: allowed }] }] as any} )
+      await addCommentToUncommittedPRs(api, pr, getFakeLogger(), info)
 
       expect(mockAPI.issues.createComment).not.toHaveBeenCalled()
     })
@@ -77,15 +76,32 @@ describe(addCommentToUncommittedPRs, () => {
 
   it("Does not add a comment to an already-commented PR", async () => {
     const { mockAPI, api } = createMockGitHubClient()
-    mockGetRelatedIssues.mockResolvedValue([{ number: 1, labels: [{ name: "Suggestion" }] }])
-    mockAPI.issues.listComments.mockResolvedValue({ data: [{ body: "The TypeScript team hasn't accepted the linked issue #1" }] })
 
     const pr = getPRFixture("opened")
     pr.pull_request.body = `fixes #1123`
     pr.pull_request.labels = [{ name: "For Backlog Bug" }]
 
-    await addCommentToUncommittedPRs(api, pr, getFakeLogger())
+    const info = createInfo({ 
+      comments: [{ body: "The TypeScript team hasn't accepted the linked issue #1" }] as any,
+      relatedIssues: [{ number: 1, labels: [{ name: "Suggestion" }] }] as any
+    })
+    await addCommentToUncommittedPRs(api, pr, getFakeLogger(), info)
 
     expect(mockAPI.issues.createComment).not.toHaveBeenCalled()
   })
 })
+
+
+const createInfo = (info?: Partial<PRInfo>): PRInfo => {
+  return {
+    comments: [],
+    authorIsMemberOfTSTeam: false,
+    relatedIssues: [],
+    thisIssue: {
+      issue_number: 35454,
+      owner: "microsoft",
+      repo: "TypeScript",
+    },
+    ...info
+  }
+}

--- a/src/checks/addLabelForTeamMember.test.ts
+++ b/src/checks/addLabelForTeamMember.test.ts
@@ -1,18 +1,17 @@
 jest.mock("../pr_meta/isMemberOfTSTeam")
 
 import { addLabelForTeamMember } from "./addLabelForTeamMember"
-import { createMockGitHubClient, convertToOctokitAPI, getPRFixture } from "../util/tests/createMockGitHubClient"
+import { createMockGitHubClient, getPRFixture } from "../util/tests/createMockGitHubClient"
 import { getFakeLogger } from "../util/tests/createMockContext"
 
-import { isMemberOfTSTeam } from "../pr_meta/isMemberOfTSTeam"
-const mockIsMember = (isMemberOfTSTeam as any) as jest.Mock
+import { createPRInfo } from "../util/tests/createPRInfo"
 
 describe(addLabelForTeamMember, () => {
   it("Adds the label when a team member writes a PR ", async () => {
     const { mockAPI, api } = createMockGitHubClient()
-    mockIsMember.mockResolvedValue(true)
 
-    await addLabelForTeamMember(api, getPRFixture("opened"), getFakeLogger())
+    const info = createPRInfo({ authorIsMemberOfTSTeam: true })
+    await addLabelForTeamMember(api, getPRFixture("opened"), getFakeLogger(), info)
 
     expect(mockAPI.issues.addLabels).toHaveBeenCalledWith({
       issue_number: 35454,
@@ -24,10 +23,10 @@ describe(addLabelForTeamMember, () => {
 
   it("Does not set the assignment when they are not a team member", async () => {
     const { mockAPI, api } = createMockGitHubClient()
-    mockIsMember.mockResolvedValue(false)
     mockAPI.issues.addAssignees.mockResolvedValue({})
 
-    await addLabelForTeamMember(api, getPRFixture("opened"), getFakeLogger())
+    const info = createPRInfo({ authorIsMemberOfTSTeam: false })
+    await addLabelForTeamMember(api, getPRFixture("opened"), getFakeLogger(), info)
 
     expect(mockAPI.issues.addAssignees).not.toHaveBeenCalled()
   })

--- a/src/checks/addLabelForTeamMember.ts
+++ b/src/checks/addLabelForTeamMember.ts
@@ -1,17 +1,16 @@
 import { WebhookPayloadPullRequest } from "@octokit/webhooks"
 import { Octokit } from "@octokit/rest"
-import { isMemberOfTSTeam } from "../pr_meta/isMemberOfTSTeam"
 import type { Logger } from "@azure/functions"
+import type { PRInfo } from "../anyRepoHandlePullRequest"
 
 /**
  * If the PR comes from a core contributor, add a label to indicate it came from a maintainer
  */
-export const addLabelForTeamMember = async (api: Octokit, payload: WebhookPayloadPullRequest, logger: Logger) => {
+export const addLabelForTeamMember = async (api: Octokit, payload: WebhookPayloadPullRequest, logger: Logger, info: PRInfo) => {
   const { repository: repo, pull_request } = payload
 
   // Check the access level of the user
-  const isTeamMember = await isMemberOfTSTeam(pull_request.user.login, api, logger)
-  if (!isTeamMember) {
+  if (!info.authorIsMemberOfTSTeam) {
     return logger.info(`Skipping because ${pull_request.user.login} is not a member of the TS team`)
   }
 

--- a/src/util/tests/createPRInfo.ts
+++ b/src/util/tests/createPRInfo.ts
@@ -1,0 +1,15 @@
+import type { PRInfo } from "../../anyRepoHandlePullRequest"
+
+export const createPRInfo = (info?: Partial<PRInfo>): PRInfo => {
+  return {
+    comments: [],
+    authorIsMemberOfTSTeam: false,
+    relatedIssues: [],
+    thisIssue: {
+      issue_number: 35454,
+      owner: "microsoft",
+      repo: "TypeScript",
+    },
+    ...info
+  }
+}


### PR DESCRIPTION
This moves a lot of the API work from inside the check to beforehand, @sandersn noted that we were making these API calls in other runs and centralization is probably a net win. 

The key point of the PR is this:

```ts
  const options = api.issues.listComments.endpoint.merge(thisIssue)
  const comments: Octokit.IssuesListCommentsResponse = await api.paginate(options)
```

Which I think should stop incidents like the comment spam in https://github.com/microsoft/TypeScript/pull/39669