### PR TITLE
Adds the ability to run repros instantly after they have been added

### DIFF
--- a/src/checks/addReprosLabel.test.ts
+++ b/src/checks/addReprosLabel.test.ts
@@ -56,7 +56,8 @@ describe(addReprosLabelOnComments, () => {
 
     await addReprosLabelOnComments(api, payload, getFakeLogger())
 
-    expect(mockAPI.issues.addLabels).not.toHaveBeenCalledWith()
+    expect(mockAPI.issues.addLabels).not.toHaveBeenCalled()
+    expect(mockAPI.repos.createDispatchEvent).not.toHaveBeenCalled()
   })
 
   it("NO-OPs when there are no labels already ", async () => {
@@ -68,6 +69,7 @@ describe(addReprosLabelOnComments, () => {
     await addReprosLabelOnComments(api, payload, getFakeLogger())
 
     expect(mockAPI.issues.addLabels).not.toHaveBeenCalledWith()
+    expect(mockAPI.repos.createDispatchEvent).not.toHaveBeenCalled()
   })
 
   it("Adds the label when it has a repro in the body and there are labels already", async () => {
@@ -84,6 +86,7 @@ describe(addReprosLabelOnComments, () => {
       owner: "microsoft",
       repo: "TypeScript-Website",
     })
+    expect(mockAPI.repos.createDispatchEvent).toHaveBeenCalled()
     expect(pingDiscord).toHaveBeenCalled()
   })
 

--- a/src/checks/addReprosLabel.ts
+++ b/src/checks/addReprosLabel.ts
@@ -47,6 +47,9 @@ export const addReprosLabelOnIssue = async (api: Octokit, payload: WebhookPayloa
     if (issue.labels.find(l => l.name === "Repro Requested")) {
       await api.issues.removeLabel({ ...thisIssue, name: "Repro Requested" })
     }
+
+    // Trigger a run of all repros
+    api.repos.createDispatchEvent({ ...thisIssue, event_type: "run-twoslash-repros" })
   }
 }
 
@@ -88,5 +91,8 @@ export const addReprosLabelOnComments = async (
     if (issue.labels.find(l => l.name === "Repro Requested")) {
       await api.issues.removeLabel({ ...thisIssue, name: "Repro Requested" })
     }
+
+    // Trigger a run of all repros
+    api.repos.createDispatchEvent({ ...thisIssue, event_type: "run-twoslash-repros" })
   }
 }

--- a/src/util/tests/createMockGitHubClient.ts
+++ b/src/util/tests/createMockGitHubClient.ts
@@ -25,6 +25,7 @@ export const createMockGitHubClient = () => {
       checkCollaborator: jest.fn(),
       getContents: jest.fn(),
       getCombinedStatusForRef: jest.fn(),
+      createDispatchEvent: jest.fn()
     },
     issues: {
       addAssignees: jest.fn(),
@@ -82,6 +83,7 @@ export const createFakeGitHubClient = () => {
       checkCollaborator: Promise.resolve({}),
       getContents: Promise.resolve({}),
       getCombinedStatusForRef: Promise.resolve({}),
+      createDispatchEvent: Promise.resolve({}),
     },
     issues: {
       addAssignees: Promise.resolve({}),


### PR DESCRIPTION
In https://github.com/microsoft/TypeScript/issues/290 I was reminded that @rbuckton felt the wait for the first repro was a bit long, and I agree, now the _first time_ a repro is detected it automatically runs. Otherwise it continues to just run the usual nightly task.