### PR TITLE
Re-ignore typescript-bot

### DIFF
--- a/src/anyRepoHandlePullRequest.ts
+++ b/src/anyRepoHandlePullRequest.ts
@@ -64,7 +64,7 @@ const generatePRInfo = async (api: Octokit, payload: PullRequestEvent, logger: L
   return {
     thisIssue,
     authorIsMemberOfTSTeam,
-    authorIsBot: payload.pull_request.user.type === "Bot",
+    authorIsBot: payload.pull_request.user.login === "typescript-bot" || payload.pull_request.user.type === "Bot",
     relatedIssues,
     comments 
   }


### PR DESCRIPTION
I screwed this up in #49; typescript-bot is not a "bot" to github so needs to be special cased.