### PR TITLE
Match tags case-insensitively for uncommitted PRs

### DIFF
--- a/src/checks/addCommentToUncommittedPRs.test.ts
+++ b/src/checks/addCommentToUncommittedPRs.test.ts
@@ -67,7 +67,7 @@ describe(addCommentToUncommittedPRs, () => {
     expect(mockAPI.issues.createComment).not.toHaveBeenCalled()
   })
 
-  for (const allowed of ["Experience Enhancement", "Committed", "help wanted"]) {
+  for (const allowed of ["Experience Enhancement", "Committed", "Help Wanted", "help wanted"]) {
     it("Does not add a comment to an uncommented PR linked to a suggestion with the label " + allowed, async () => {
       const { mockAPI, api } = createMockGitHubClient()
       

--- a/src/checks/addCommentToUncommittedPRs.ts
+++ b/src/checks/addCommentToUncommittedPRs.ts
@@ -25,11 +25,11 @@ export const addCommentToUncommittedPRs = async (api: Octokit, payload: PullRequ
   else {
     const isSuggestion = info.relatedIssues.some(issue => issue.labels?.find(l => {
       const name = typeof l === "string" ? l : l.name;
-      return name === "Suggestion"
+      return name?.toLowerCase() === "suggestion"
     }))
     const isCommitted = info.relatedIssues.some(issue => issue.labels?.find(l => {
       const name = typeof l === "string" ? l : l.name;
-      return name === "Committed" || name === "Experience Enhancement" || name === "help wanted"
+      return name?.toLowerCase() === "committed" || name?.toLowerCase() === "experience enhancement" || name?.toLowerCase() === "help wanted"
     }))
 
     if (isSuggestion && !isCommitted) {


### PR DESCRIPTION
A pull request for an issue I'm following received a comment (https://github.com/microsoft/TypeScript/pull/62323#issuecomment-3217178572) saying the linked issue hasn't been committed. However, the linked issue (https://github.com/microsoft/TypeScript/issues/58561) seems to be committed, and properly marked as such. I suppose `help wanted` was changed to `Help Wanted` in the repo at some point in time.

We could of course just fix the case of the one string literal, let me know if that's preferred. It just felt prudent to switch to a case-insensitive comparison, e.g. in case the check gets used in other repos (I noticed [microsoft/typescript-go](https://github.com/microsoft/typescript-go/) uses the lowercase tag name).

There are other label checks in the codebase that are case sensitive, let me know if you'd like me to touch those as well. I left them as they are for now.