### PR TITLE
Auto close non-team PRs that touch generated DOM files

### DIFF
--- a/src/anyRepoHandlePullRequest.ts
+++ b/src/anyRepoHandlePullRequest.ts
@@ -13,6 +13,7 @@ import { HttpResponseInit, InvocationContext } from "@azure/functions"
 import { Logger } from "./util/logger.js"
 import { isTypeScriptBot } from "./util/botUsers.js"
 import { isTypeScriptRepo } from "./util/isTypeScriptRepo.js"
+import { closeGeneratedDomLibPRs } from "./checks/closeGeneratedDomLibPRs.js"
 
 export const handlePullRequestPayload = async (payload: PullRequestEvent, context: InvocationContext): Promise<HttpResponseInit> => {
   if (
@@ -29,9 +30,9 @@ export const handlePullRequestPayload = async (payload: PullRequestEvent, contex
   const api = await createGitHubClient(payload.repository.owner.login, payload.repository.name)
   const ran = [] as string[]
 
-  const run = (
+  const run = <T>(
     name: string,
-    fn: (api: Octokit, payload: PullRequestEvent, logger: Logger, pr: PRInfo) => Promise<void>,
+    fn: (api: Octokit, payload: PullRequestEvent, logger: Logger, pr: PRInfo) => Promise<T>,
     pr: PRInfo
   ) => {
     context.info(`\n\n## ${name}\n`)
@@ -40,6 +41,14 @@ export const handlePullRequestPayload = async (payload: PullRequestEvent, contex
   }
 
   const pr = await generatePRInfo(api, payload, context)
+
+  if (await run("Closing external PRs that modify generated DOM libraries", closeGeneratedDomLibPRs, pr)) {
+    return {
+      status: 200,
+      headers: { sha },
+      body: `PR success, ran: ${ran.join(", ")}`,
+    }
+  }
 
   await run("Assigning Self to Core Team PRs", assignSelfToNewPullRequest, pr)
   await run("Add a core team label to PRs", addLabelForTeamMember, pr)

--- a/src/checks/addCommentToUncommittedPRs.test.ts
+++ b/src/checks/addCommentToUncommittedPRs.test.ts
@@ -67,10 +67,10 @@ describe(addCommentToUncommittedPRs, () => {
 
   it("Adds only one comment when checks for the same PR run concurrently", async () => {
     const { mockAPI, api } = createMockGitHubClient()
-    const comments: { body: string }[] = []
+    const comments: { body: string, user: { login: string } }[] = []
     mockAPI.paginate.mockImplementation(async () => comments)
     mockAPI.issues.createComment.mockImplementation(async ({ body }) => {
-      comments.push({ body })
+      comments.push({ body, user: { login: "typescript-automation[bot]" } })
     })
 
     const pr = getPRFixture("opened")
@@ -117,7 +117,10 @@ describe(addCommentToUncommittedPRs, () => {
     pr.pull_request.labels = [{ name: "For Backlog Bug" } as Partial<Label> as Label]
 
     const info = createPRInfo({ 
-      comments: [{ body: "The TypeScript team hasn't accepted the linked issue #1" }] as any,
+      comments: [{
+        body: "The TypeScript team hasn't accepted the linked issue #1",
+        user: { login: "typescript-automation[bot]" },
+      }] as any,
       relatedIssues: [{ number: 1, labels: [{ name: "Suggestion" }] }] as any
     })
     await addCommentToUncommittedPRs(api, pr, getFakeLogger(), info)

--- a/src/checks/addCommentToUncommittedPRs.ts
+++ b/src/checks/addCommentToUncommittedPRs.ts
@@ -2,46 +2,7 @@ import { PullRequestEvent } from "@octokit/webhooks-types"
 import { Octokit } from "@octokit/rest"
 import type { PRInfo } from "../anyRepoHandlePullRequest.js"
 import { Logger } from "../util/logger.js"
-
-const pendingCommentChecks = new Map<string, Promise<void>>()
-
-const acquireCommentLock = async (key: string) => {
-  const previous = pendingCommentChecks.get(key)
-  let release!: () => void
-  const current = new Promise<void>(resolve => {
-    release = resolve
-  })
-  pendingCommentChecks.set(key, current)
-
-  if (previous) {
-    await previous
-  }
-
-  return {
-    [Symbol.dispose]() {
-      release()
-      if (pendingCommentChecks.get(key) === current) {
-        pendingCommentChecks.delete(key)
-      }
-    }
-  }
-}
-
-const addCommentIfMissing = async (api: Octokit, info: PRInfo, message: string) => {
-  if (info.comments.some(comment => comment.body?.startsWith(message.slice(0, 25)))) {
-    return
-  }
-
-  const key = `${info.thisIssue.owner}/${info.thisIssue.repo}#${info.thisIssue.issue_number}`
-  using _lock = await acquireCommentLock(key)
-  const comments = await api.paginate(api.issues.listComments, info.thisIssue)
-  if (!comments.some(comment => comment.body?.startsWith(message.slice(0, 25)))) {
-    await api.issues.createComment({
-      ...info.thisIssue,
-      body: message
-    })
-  }
-}
+import { addCommentIfMissing } from "../util/addCommentIfMissing.js"
 
 /**
  * Comment on new PRs that don't have linked issues, or link to uncommitted issues.

--- a/src/checks/closeGeneratedDomLibPRs.test.ts
+++ b/src/checks/closeGeneratedDomLibPRs.test.ts
@@ -108,6 +108,7 @@ describe(closeGeneratedDomLibPRs, () => {
       createPRInfo({
         comments: [{
           body: "It looks like you've sent a pull request that updates generated declaration files related to the DOM.",
+          user: { login: "typescript-automation[bot]" },
         }] as any,
       }),
     )
@@ -122,6 +123,7 @@ describe(closeGeneratedDomLibPRs, () => {
       .mockResolvedValueOnce([{ filename: generatedDomLibFiles[0] }])
       .mockResolvedValueOnce([{
         body: "It looks like you've sent a pull request that updates generated declaration files related to the DOM.",
+        user: { login: "typescript-automation[bot]" },
       }])
 
     await closeGeneratedDomLibPRs(
@@ -132,6 +134,28 @@ describe(closeGeneratedDomLibPRs, () => {
     )
 
     expect(mockAPI.issues.createComment).not.toHaveBeenCalled()
+    expect(mockAPI.pulls.update).toHaveBeenCalled()
+  })
+
+  it("does not accept a matching comment from the PR author", async () => {
+    const { mockAPI, api } = createMockGitHubClient()
+    mockAPI.paginate
+      .mockResolvedValueOnce([{ filename: generatedDomLibFiles[0] }])
+      .mockResolvedValueOnce([])
+
+    await closeGeneratedDomLibPRs(
+      api,
+      getPRFixture("opened"),
+      getFakeLogger(),
+      createPRInfo({
+        comments: [{
+          body: "It looks like you've sent a pull request that updates generated declaration files related to the DOM.",
+          user: { login: "external-contributor" },
+        }] as any,
+      }),
+    )
+
+    expect(mockAPI.issues.createComment).toHaveBeenCalled()
     expect(mockAPI.pulls.update).toHaveBeenCalled()
   })
 })

--- a/src/checks/closeGeneratedDomLibPRs.test.ts
+++ b/src/checks/closeGeneratedDomLibPRs.test.ts
@@ -77,6 +77,26 @@ describe(closeGeneratedDomLibPRs, () => {
     expect(mockAPI.pulls.update).not.toHaveBeenCalled()
   })
 
+  it("closes an external PR that renames a generated DOM library file", async () => {
+    const { mockAPI, api } = createMockGitHubClient()
+    mockAPI.paginate
+      .mockResolvedValueOnce([{
+        filename: "renamed.d.ts",
+        previous_filename: generatedDomLibFiles[0],
+      }])
+      .mockResolvedValueOnce([])
+
+    const closed = await closeGeneratedDomLibPRs(
+      api,
+      getPRFixture("opened"),
+      getFakeLogger(),
+      createPRInfo(),
+    )
+
+    expect(closed).toBe(true)
+    expect(mockAPI.pulls.update).toHaveBeenCalled()
+  })
+
   it("does not repeat the explanation comment", async () => {
     const { mockAPI, api } = createMockGitHubClient()
     mockAPI.paginate.mockResolvedValue([{ filename: generatedDomLibFiles[0] }])
@@ -90,6 +110,25 @@ describe(closeGeneratedDomLibPRs, () => {
           body: "It looks like you've sent a pull request that updates generated declaration files related to the DOM.",
         }] as any,
       }),
+    )
+
+    expect(mockAPI.issues.createComment).not.toHaveBeenCalled()
+    expect(mockAPI.pulls.update).toHaveBeenCalled()
+  })
+
+  it("rechecks comments before adding the explanation", async () => {
+    const { mockAPI, api } = createMockGitHubClient()
+    mockAPI.paginate
+      .mockResolvedValueOnce([{ filename: generatedDomLibFiles[0] }])
+      .mockResolvedValueOnce([{
+        body: "It looks like you've sent a pull request that updates generated declaration files related to the DOM.",
+      }])
+
+    await closeGeneratedDomLibPRs(
+      api,
+      getPRFixture("opened"),
+      getFakeLogger(),
+      createPRInfo(),
     )
 
     expect(mockAPI.issues.createComment).not.toHaveBeenCalled()

--- a/src/checks/closeGeneratedDomLibPRs.test.ts
+++ b/src/checks/closeGeneratedDomLibPRs.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest"
+import { closeGeneratedDomLibPRs, generatedDomLibFiles } from "./closeGeneratedDomLibPRs.js"
+import { createMockGitHubClient, getPRFixture } from "../util/tests/createMockGitHubClient.js"
+import { getFakeLogger } from "../util/tests/createMockContext.js"
+import { createPRInfo } from "../util/tests/createPRInfo.js"
+
+describe(closeGeneratedDomLibPRs, () => {
+  it.each(generatedDomLibFiles)("closes an external PR that modifies %s", async filename => {
+    const { mockAPI, api } = createMockGitHubClient()
+    mockAPI.paginate.mockResolvedValue([{ filename }])
+
+    const closed = await closeGeneratedDomLibPRs(
+      api,
+      getPRFixture("opened"),
+      getFakeLogger(),
+      createPRInfo(),
+    )
+
+    expect(closed).toBe(true)
+    expect(mockAPI.issues.createComment).toHaveBeenCalledWith({
+      owner: "microsoft",
+      repo: "TypeScript",
+      issue_number: 35454,
+      body: expect.stringContaining("TypeScript-DOM-lib-generator"),
+    })
+    expect(mockAPI.pulls.update).toHaveBeenCalledWith({
+      owner: "microsoft",
+      repo: "TypeScript",
+      pull_number: 35454,
+      state: "closed",
+    })
+  })
+
+  it("does not close a team member's PR", async () => {
+    const { mockAPI, api } = createMockGitHubClient()
+
+    const closed = await closeGeneratedDomLibPRs(
+      api,
+      getPRFixture("opened"),
+      getFakeLogger(),
+      createPRInfo({ authorIsMemberOfTSTeam: true }),
+    )
+
+    expect(closed).toBe(false)
+    expect(mockAPI.paginate).not.toHaveBeenCalled()
+    expect(mockAPI.pulls.update).not.toHaveBeenCalled()
+  })
+
+  it("does not close a bot's PR", async () => {
+    const { mockAPI, api } = createMockGitHubClient()
+
+    const closed = await closeGeneratedDomLibPRs(
+      api,
+      getPRFixture("opened"),
+      getFakeLogger(),
+      createPRInfo({ authorIsBot: true }),
+    )
+
+    expect(closed).toBe(false)
+    expect(mockAPI.paginate).not.toHaveBeenCalled()
+    expect(mockAPI.pulls.update).not.toHaveBeenCalled()
+  })
+
+  it("does not close a PR that only modifies other files", async () => {
+    const { mockAPI, api } = createMockGitHubClient()
+    mockAPI.paginate.mockResolvedValue([{ filename: "src/compiler/checker.ts" }])
+
+    const closed = await closeGeneratedDomLibPRs(
+      api,
+      getPRFixture("opened"),
+      getFakeLogger(),
+      createPRInfo(),
+    )
+
+    expect(closed).toBe(false)
+    expect(mockAPI.issues.createComment).not.toHaveBeenCalled()
+    expect(mockAPI.pulls.update).not.toHaveBeenCalled()
+  })
+
+  it("does not repeat the explanation comment", async () => {
+    const { mockAPI, api } = createMockGitHubClient()
+    mockAPI.paginate.mockResolvedValue([{ filename: generatedDomLibFiles[0] }])
+
+    await closeGeneratedDomLibPRs(
+      api,
+      getPRFixture("opened"),
+      getFakeLogger(),
+      createPRInfo({
+        comments: [{
+          body: "It looks like you've sent a pull request that updates generated declaration files related to the DOM.",
+        }] as any,
+      }),
+    )
+
+    expect(mockAPI.issues.createComment).not.toHaveBeenCalled()
+    expect(mockAPI.pulls.update).toHaveBeenCalled()
+  })
+})

--- a/src/checks/closeGeneratedDomLibPRs.ts
+++ b/src/checks/closeGeneratedDomLibPRs.ts
@@ -1,6 +1,7 @@
 import { Octokit } from "@octokit/rest"
 import { PullRequestEvent } from "@octokit/webhooks-types"
 import type { PRInfo } from "../anyRepoHandlePullRequest.js"
+import { addCommentIfMissing } from "../util/addCommentIfMissing.js"
 import { Logger } from "../util/logger.js"
 
 export const generatedDomLibFiles = [
@@ -41,17 +42,15 @@ export const closeGeneratedDomLibPRs = async (
     per_page: 100,
   })
 
-  if (!files.some(file => generatedDomLibFileSet.has(file.filename))) {
+  if (!files.some(file =>
+    generatedDomLibFileSet.has(file.filename)
+    || file.previous_filename !== undefined && generatedDomLibFileSet.has(file.previous_filename)
+  )) {
     logger.trace("Pull request does not modify generated DOM library files")
     return false
   }
 
-  if (!info.comments.some(comment => comment.body?.startsWith(message.slice(0, 25)))) {
-    await api.issues.createComment({
-      ...info.thisIssue,
-      body: message,
-    })
-  }
+  await addCommentIfMissing(api, info, message)
 
   await api.pulls.update({
     owner: repo.owner.login,

--- a/src/checks/closeGeneratedDomLibPRs.ts
+++ b/src/checks/closeGeneratedDomLibPRs.ts
@@ -1,0 +1,64 @@
+import { Octokit } from "@octokit/rest"
+import { PullRequestEvent } from "@octokit/webhooks-types"
+import type { PRInfo } from "../anyRepoHandlePullRequest.js"
+import { Logger } from "../util/logger.js"
+
+export const generatedDomLibFiles = [
+  "tsc/internal/bundled/libs/lib.dom.d.ts",
+  "tsc/internal/bundled/libs/lib.dom.asynciterable.d.ts",
+  "tsc/internal/bundled/libs/lib.dom.iterable.d.ts",
+  "tsc/internal/bundled/libs/lib.webworker.d.ts",
+  "tsc/internal/bundled/libs/lib.webworker.asynciterable.d.ts",
+  "tsc/internal/bundled/libs/lib.webworker.iterable.d.ts",
+] as const
+
+const generatedDomLibFileSet: ReadonlySet<string> = new Set(generatedDomLibFiles)
+
+const message = [
+  "It looks like you've sent a pull request that updates generated declaration files related to the DOM.",
+  "These files aren't meant to be edited by hand; they are generated from",
+  "[the TypeScript-DOM-lib-generator repository](https://github.com/microsoft/TypeScript-DOM-lib-generator).",
+  "Please make the change in that repository instead.",
+  "For housekeeping purposes, this pull request will be closed.",
+].join(" ")
+
+export const closeGeneratedDomLibPRs = async (
+  api: Octokit,
+  payload: PullRequestEvent,
+  logger: Logger,
+  info: PRInfo,
+) => {
+  if (payload.pull_request.state === "closed" || info.authorIsMemberOfTSTeam || info.authorIsBot) {
+    logger.trace("Skipping generated DOM library check")
+    return false
+  }
+
+  const { repository: repo, pull_request } = payload
+  const files = await api.paginate(api.pulls.listFiles, {
+    owner: repo.owner.login,
+    repo: repo.name,
+    pull_number: pull_request.number,
+    per_page: 100,
+  })
+
+  if (!files.some(file => generatedDomLibFileSet.has(file.filename))) {
+    logger.trace("Pull request does not modify generated DOM library files")
+    return false
+  }
+
+  if (!info.comments.some(comment => comment.body?.startsWith(message.slice(0, 25)))) {
+    await api.issues.createComment({
+      ...info.thisIssue,
+      body: message,
+    })
+  }
+
+  await api.pulls.update({
+    owner: repo.owner.login,
+    repo: repo.name,
+    pull_number: pull_request.number,
+    state: "closed",
+  })
+  logger.info("Closed pull request that modifies generated DOM library files")
+  return true
+}

--- a/src/util/addCommentIfMissing.ts
+++ b/src/util/addCommentIfMissing.ts
@@ -1,0 +1,42 @@
+import { Octokit } from "@octokit/rest"
+import type { PRInfo } from "../anyRepoHandlePullRequest.js"
+
+const pendingCommentChecks = new Map<string, Promise<void>>()
+
+const acquireCommentLock = async (key: string) => {
+  const previous = pendingCommentChecks.get(key)
+  let release!: () => void
+  const current = new Promise<void>(resolve => {
+    release = resolve
+  })
+  pendingCommentChecks.set(key, current)
+
+  if (previous) {
+    await previous
+  }
+
+  return {
+    [Symbol.dispose]() {
+      release()
+      if (pendingCommentChecks.get(key) === current) {
+        pendingCommentChecks.delete(key)
+      }
+    }
+  }
+}
+
+export const addCommentIfMissing = async (api: Octokit, info: PRInfo, message: string) => {
+  if (info.comments.some(comment => comment.body?.startsWith(message.slice(0, 25)))) {
+    return
+  }
+
+  const key = `${info.thisIssue.owner}/${info.thisIssue.repo}#${info.thisIssue.issue_number}`
+  using _lock = await acquireCommentLock(key)
+  const comments = await api.paginate(api.issues.listComments, info.thisIssue)
+  if (!comments.some(comment => comment.body?.startsWith(message.slice(0, 25)))) {
+    await api.issues.createComment({
+      ...info.thisIssue,
+      body: message
+    })
+  }
+}

--- a/src/util/addCommentIfMissing.ts
+++ b/src/util/addCommentIfMissing.ts
@@ -1,5 +1,6 @@
 import { Octokit } from "@octokit/rest"
 import type { PRInfo } from "../anyRepoHandlePullRequest.js"
+import { isTypeScriptBot } from "./botUsers.js"
 
 const pendingCommentChecks = new Map<string, Promise<void>>()
 
@@ -26,14 +27,17 @@ const acquireCommentLock = async (key: string) => {
 }
 
 export const addCommentIfMissing = async (api: Octokit, info: PRInfo, message: string) => {
-  if (info.comments.some(comment => comment.body?.startsWith(message.slice(0, 25)))) {
+  const isMatchingBotComment = (comment: { body?: string | null, user?: { login?: string } | null }) =>
+    isTypeScriptBot(comment.user?.login) && comment.body?.startsWith(message.slice(0, 25))
+
+  if (info.comments.some(isMatchingBotComment)) {
     return
   }
 
   const key = `${info.thisIssue.owner}/${info.thisIssue.repo}#${info.thisIssue.issue_number}`
   using _lock = await acquireCommentLock(key)
   const comments = await api.paginate(api.issues.listComments, info.thisIssue)
-  if (!comments.some(comment => comment.body?.startsWith(message.slice(0, 25)))) {
+  if (!comments.some(isMatchingBotComment)) {
     await api.issues.createComment({
       ...info.thisIssue,
       body: message

--- a/src/util/tests/createMockGitHubClient.ts
+++ b/src/util/tests/createMockGitHubClient.ts
@@ -38,6 +38,7 @@ export const createMockGitHubClient = () => {
     },
     pulls: {
       get: vi.fn(),
+      update: vi.fn(),
       listFiles: {
         endpoint: {
           merge: vi.fn(),
@@ -95,6 +96,7 @@ export const createFakeGitHubClient = () => {
     },
     pulls: {
       get: Promise.resolve({}),
+      update: Promise.resolve({}),
       listFiles: Promise.resolve({}),
     },
     checks: {


### PR DESCRIPTION
Replace the old `pr-modified-files` workflow.