### PR TITLE
Roll back Azure Functions to Node 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,11 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: '24.x'
-  AZURE_NODE_VERSION: '~24'
+  NODE_VERSION: '22.x'
+  AZURE_NODE_VERSION: '~22'
   RESOURCE_GROUP_NAME: TypeScriptReposAutomation2
   FUNCTION_APP_NAME: TypeScriptReposAutomation2
+  FUNCTION_APP_HOST_NAME: typescriptreposautomation-d0gkhdf5d7h4fce4.b02.azurefd.net
   STORAGE_ACCOUNT_NAME: typescriptreposauto997e
   STORAGE_CONTAINER_NAME: deployment
   FUNCTION_ZIP_NAME: function.zip
@@ -87,3 +88,16 @@ jobs:
 
       - name: Restart app
         run: az functionapp restart -g ${{ env.RESOURCE_GROUP_NAME }} -n ${{ env.FUNCTION_APP_NAME }}
+
+      - name: Verify app startup
+        run: |
+          for attempt in {1..12}; do
+            status=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+              https://${{ env.FUNCTION_APP_HOST_NAME }}/api/TypeScriptRepoPullRequestWebhook || true)
+            if [[ "$status" == "500" ]]; then
+              exit 0
+            fi
+            echo "Attempt $attempt returned HTTP $status"
+            sleep 10
+          done
+          exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,16 +17,16 @@
             },
             "devDependencies": {
                 "@octokit/webhooks-types": "^7.6.1",
-                "@tsconfig/node24": "^24.0.4",
+                "@tsconfig/node22": "^22.0.5",
                 "@tsconfig/strictest": "^2.0.8",
-                "@types/node": "^24.13.3",
+                "@types/node": "^22.19.13",
                 "esbuild": "^0.28.2",
                 "knip": "^6.32.2",
                 "typescript": "^7.0.2",
                 "vitest": "^4.1.10"
             },
             "engines": {
-                "node": ">=24"
+                "node": ">=22"
             }
         },
         "node_modules/@azure-rest/core-client": {
@@ -1901,10 +1901,10 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@tsconfig/node24": {
-            "version": "24.0.4",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node24/-/node24-24.0.4.tgz",
-            "integrity": "sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==",
+        "node_modules/@tsconfig/node22": {
+            "version": "22.0.6",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.6.tgz",
+            "integrity": "sha512-/5thavHAnWDZwH2H6eEn/T8pBEBhtuKaWGMslsj82kJfvzQgOgEMK7X4goBbIUjgVtAzPTtM9Ml64LA0uxO6Iw==",
             "dev": true,
             "license": "MIT"
         },
@@ -1952,13 +1952,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.13.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-            "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+            "version": "22.20.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+            "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.18.0"
+                "undici-types": "~6.21.0"
             }
         },
         "node_modules/@typescript/typescript-aix-ppc64": {
@@ -3657,9 +3657,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.18.2",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "",
   "private": true,
   "engines": {
-    "node": ">=24"
+    "node": ">=22"
   },
   "main": "dist/functions/index.js",
   "scripts": {
     "build": "tsc",
     "postinstall": "node scripts/printSHA.js",
-    "bundle": "esbuild --bundle --platform=node --format=cjs --target=node24 --external:@azure/functions-core --outfile=dist/functions/index.js src/functions/index.ts",
+    "bundle": "esbuild --bundle --platform=node --format=cjs --target=node22 --external:@azure/functions-core --outfile=dist/functions/index.js src/functions/index.ts",
     "watch": "tsc -w",
     "prestart": "npm run build",
     "start": "func start",
@@ -25,9 +25,9 @@
   },
   "devDependencies": {
     "@octokit/webhooks-types": "^7.6.1",
-    "@tsconfig/node24": "^24.0.4",
+    "@tsconfig/node22": "^22.0.5",
     "@tsconfig/strictest": "^2.0.8",
-    "@types/node": "^24.13.3",
+    "@types/node": "^22.19.13",
     "esbuild": "^0.28.2",
     "knip": "^6.32.2",
     "typescript": "^7.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["@tsconfig/node24", "@tsconfig/strictest"],
+  "extends": ["@tsconfig/node22", "@tsconfig/strictest"],
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
The Node 24 deployment caused the Windows Azure Function host to fail during worker indexing with:

```text
node exited with code 1
SyntaxError: Use of const in strict mode.
```

Application Insights recorded 4,518 startup failures beginning immediately after the runtime change, and the Front Door endpoint returned `503 Function host is not running`.

This rolls the build and deployed runtime back to Node 22 and adds a post-deployment probe through Front Door. An unsigned request should return 500 from webhook verification; a 503 indicates that the function host did not start.

The production app setting has already been rolled back to `~22`, restoring the expected webhook response.