### PR TITLE
Fix related PR GraphQL query

### DIFF
--- a/src/issue_meta/getRelatedPRs.test.ts
+++ b/src/issue_meta/getRelatedPRs.test.ts
@@ -38,6 +38,17 @@ describe(getRelatedPRs, () => {
     ])
     expect(mockAPI.graphql).toHaveBeenCalledTimes(2)
     expect(mockAPI.issues.get).toHaveBeenCalledTimes(2)
+
+    const query: unknown = mockAPI.graphql.mock.calls[0]?.[0]
+    expect(typeof query).toBe("string")
+    if (typeof query !== "string") throw new Error("Expected a GraphQL query")
+    let braceDepth = 0
+    for (const character of query) {
+      if (character === "{") braceDepth++
+      if (character === "}") braceDepth--
+      expect(braceDepth).toBeGreaterThanOrEqual(0)
+    }
+    expect(braceDepth).toBe(0)
   })
 
   it("rejects an incomplete pagination response", async () => {

--- a/src/issue_meta/getRelatedPRs.ts
+++ b/src/issue_meta/getRelatedPRs.ts
@@ -52,6 +52,7 @@ export const getRelatedPRs = async (
             }
           }
         }
+      }
       `,
       {
         owner,


### PR DESCRIPTION
Close the outer operation block in the `getRelatedPRs` GraphQL query.

The missing brace causes issue milestone webhook deliveries to fail with:

```text
Expected NAME, actual: (none) ("") at [20, 9]
```

Add a regression assertion that the generated query has balanced braces.